### PR TITLE
adding r packages - except reddyproc - to conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: ctsm-py
 channels:
     - conda-forge
+    - bioconda
     - defaults
 dependencies:
     - python=3.7    # Python version 3.7
@@ -26,3 +27,10 @@ dependencies:
     - six           # Python 2/3 compatibility
     - tqdm          # Nice progressbar for longer computations
     - xarray=0.16.2 # N-d labeled array library
+    - r-base        # R base code
+    - r-essentials
+    - r-ncdf4
+    - r-devtools
+    - r-eml
+    - r-rcurl
+    - bioconductor-rhdf5


### PR DESCRIPTION
@wwieder I've updated the conda environment to include R packages. You can see if this solves the certificate problem by testing this branch. 

The conda environment will probably take a little while to install (it often does with R packages from conda forge because there are so many). 

I haven't looked into installing reddyproc via conda yet, so for right now, it will just install itself at the top of the script (per the script installation code at the top of the script). 

To make sure that Rstudio sees the correct environment, you can 
 1. activate the conda environment, 
 2. start rstudio from the command line - you should be able to type rstudio in the terminal and have it start, 
 3. Once Rstudio is up and running, check to make sure that `R.home()` and `.libPaths()` are referencing the conda version of R (see this [post](https://stackoverflow.com/a/62737170) for more details). 